### PR TITLE
Fix for #3: Incorrect email count

### DIFF
--- a/data/icon_notifications.js
+++ b/data/icon_notifications.js
@@ -101,13 +101,11 @@ function countUnreadMessages() {
 
   var folder_panes = document.querySelectorAll("[aria-label='Folder Pane']");
   if (folder_panes.length > 0) {
-    console.log("Found folder panes");
     for(var pane = folder_panes.length-1; pane >= 0; pane--){
       unreadContainer = folder_panes[pane].querySelectorAll("[id*='.ucount']");
       count = countIt(unreadContainer);
     }
   } else {
-    
     unreadContainer = document.querySelectorAll('#spnCV');
     var subSetunreadContainer = [];
     for(var u_node = unreadContainer.length-1; u_node>=0; u_node--) {

--- a/data/icon_notifications.js
+++ b/data/icon_notifications.js
@@ -101,13 +101,24 @@ function countUnreadMessages() {
 
   var folder_panes = document.querySelectorAll("[aria-label='Folder Pane']");
   if (folder_panes.length > 0) {
+    console.log("Found folder panes");
     for(var pane = folder_panes.length-1; pane >= 0; pane--){
       unreadContainer = folder_panes[pane].querySelectorAll("[id*='.ucount']");
       count = countIt(unreadContainer);
     }
   } else {
+    
     unreadContainer = document.querySelectorAll('#spnCV');
-    count = countIt(unreadContainer);
+    var subSetunreadContainer = [];
+    for(var u_node = unreadContainer.length-1; u_node>=0; u_node--) {
+        var container = unreadContainer[u_node];
+        var folderName = container.parentNode.parentNode.querySelector('#spnFldrNm').getAttribute("fldrnm");
+        // Can be used to check for other folder names also
+        if(folderName == "Unread Mail") {
+            subSetunreadContainer.push(container);
+        }
+    }
+    count = countIt(subSetunreadContainer);
   }
   return count;
 }


### PR DESCRIPTION
This fixes the unread email count problem for OWA 2010.
The code looks for the folder named "Unread Mail" and only counts this
one. A quick check shows that for UK English, Dutch and French this folder
name never changes.

Tested on local firefox.
![fixed_number_of_entries](https://cloud.githubusercontent.com/assets/3983738/6000122/5546f30a-aada-11e4-95f8-2cf22abd548f.png)


Future improvements: Add an option where this field can be configured
(using Unread Mail)